### PR TITLE
Add missing parenthesis for the function call

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -77,7 +77,7 @@
     "prefix": "ng2-subscribe",
     "description": "Angular 2 observable subscribe snippet",
     "body": [
-      "this.${service}.${function}",
+      "this.${service}.${function}()",
       "\t.subscribe(${arg} => this.${property} = ${arg});",
       "$0"
     ]


### PR DESCRIPTION
You ran into this on your talk at ngconf, i thought you might appreciate the fix. 
