### PR TITLE
Adding template html snippets to typescript.json

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -123,5 +123,57 @@
       "])",
       "export class AppComponent {}"
     ]
+  },
+  "ngClass": {
+    "prefix": "ng2-ngClass",
+    "body": [
+      "[ngClass]=\"{${cssClass}: ${expression}}\""
+    ],
+    "description": "Angular 2 ngClass snippet"
+  },
+  "ngFor": {
+    "prefix": "ng2-ngFor",
+    "body": [
+      "*ngFor=\"let ${item} of ${list}\""
+    ],
+    "description": "Angular 2 *ngFor snippet"
+  },
+  "ngIf": {
+    "prefix": "ng2-ngIf",
+    "body": [
+      "*ngIf=\"${expression}\""
+    ],
+    "description": "Angular 2 *ngIf snippet"
+  },
+  "ngModel": {
+    "prefix": "ng2-ngModel",
+    "body": [
+      "[(ngModel)]=\"${binding}\""
+    ],
+    "description": "Angular 2 ngModel snippet"
+  },
+  "ngRouterLink": {
+    "prefix": "ng2-routerLink",
+    "body": [
+      "[routerLink]=\"['${routeName}']\""
+    ],
+    "description": "Angular 2 routerLink snippet"
+  },
+  "ngStyle": {
+    "prefix": "ng2-ngStyle",
+    "body": [
+      "[ngStyle]=\"{${style}: ${expression}}\""
+    ],
+    "description": "Angular 2 ngStyle snippet"
+  },
+  "ngSwitch": {
+    "prefix": "ng2-ngSwitch",
+    "body": [
+      "<div [ngSwitch]=\"${conditionExpression}\">",
+      "\t<div *ngSwitchWhen=\"${expression}\">${output}</div>",
+      "\t<div *ngSwitchDefault>${output2}</div>",
+      "</div>"
+    ],
+    "description": "Angular 2 ngSwitch snippet"
   }
 }


### PR DESCRIPTION
Good afternoon John,

I found myself wanting to use the HTML snippets you created within a simple inline template I was creating within an `@Component` decorator, but since I was working within TypeScript and not an HTML file I found they were contextually unavailable. 

I am not sure if what I did by copying the HTML snippets directly into the TypeScript snippets is the best approach, but it appears to work. I figured a PR might be a better means of discussing rather than just opening a new issue with the feature request. (For instance: Perhaps the HTML snippets within the TypeScript snippets should have 'template' in their prefix name like `ng2-template-ngFor` to provide clearer intent of purpose?)

Thank you!

Michael
