### PR TITLE
ng2-ngSwitch should use *ngSwitchCase instead

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -45,7 +45,7 @@
     "prefix": "ng2-ngSwitch",
     "body": [
       "<div [ngSwitch]=\"${conditionExpression}\">",
-      "\t<div *ngSwitchWhen=\"${expression}\">${output}</div>",
+      "\t<div *ngSwitchCase=\"${expression}\">${output}</div>",
       "\t<div *ngSwitchDefault>${output2}</div>",
       "</div>"
     ],


### PR DESCRIPTION
The *ngSwitchWhen is deprecated and will be removed. Use *ngSwitchCase instead.
