### PR TITLE
fix pipe argument param - fixes #16

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -41,7 +41,7 @@
       "})",
       "",
       "export class ${PipeName}Pipe implements PipeTransform {",
-      "\ttransform(value: any, args: any[]): any {",
+      "\ttransform(value: any, ...args: any[]): any {",
       "\t\t$0",
       "\t}",
       "}"


### PR DESCRIPTION
The pipe `args` argument of the pipe `transform` method misses the the rest dots. This PR fixes #16.
