### PR TITLE
Add multiple variables to `a-output-event`

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -103,7 +103,7 @@
   "Output Event": {
     "prefix": "a-output-event",
     "body": [
-      "@Output() ${1:eventName}: EventEmitter<${1:eventType}> = new EventEmitter<${1:eventType}>();"
+      "@Output() ${1:eventName}: EventEmitter<${2:eventType}> = new EventEmitter<${2:eventType}>();"
     ],
     "description": "Angular @Output event and emitter"
   },


### PR DESCRIPTION
Fixes #56. I have checked it by inserting this snippet into my own _User snippets_ and it worked correctly.

## Purpose
Fixes single variable binding for a snippet that should have 2 - one for the name of the event and one for the type.

## What
Snippet of `a-output-event`

## How to Test
Insert into _User snippets_ and check if it has the desired behavior.

## What to Check
Verify that the following are valid
* you are able to type in a name, press _Tab_ and then provide a type for the `EventEmitter` instead of just changing both of them at the same time