### PR TITLE
Solved a mistake in the markdown README page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ rx-add-operator             // Rx add operator import
 rx-add-observable           // Rx add observable import
 ```
 
-###HTML Snippets
+### HTML Snippets
 ```html
 a-class                     // [class] binding
 a-select                    // <select> control


### PR DESCRIPTION
## Purpose
Solve a mistake in the markdown README page.

## What
The "###HTML Snippets" text is wrong.
The correct one is "### HTML Snippets".

## How to Test
Open the README.md page and go down until the text "HTML Snippets".

## What to Check
Verify that the README.md is ok with the change.
(Validated on my brach).