### PR TITLE
RxJS operators import

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Type part of a snippet, press `enter`, and the snippet unfolds.
 | `rx-behavior-subject`        | Rx `BehaviorSubject` import |
 | `rx-add-operator`            | Rx add operator import |
 | `rx-add-observable`          | Rx add observable import |
+| `rx-operators`               | Rx operators import |
 
 ### HTML Snippets
 

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -439,5 +439,10 @@
     "prefix": "rx-add-observable",
     "description": "RxJS Add Observable import",
     "body": ["import 'rxjs/add/observable/${1:of}';", "$0"]
+  },
+  "RxJS Operators": {
+    "prefix": "rx-operators",
+    "description": "RxJS Operators import",
+    "body": ["import { ${1:map} } from 'rxjs/operators';", "$0"]
   }
 }


### PR DESCRIPTION
With RxJS 5.5 and Angular 5.0.0 and above, this snippet would be really helpful

## Purpose
* snippet for import { map } from 'rxjs/operators';

## What
* Snippet

## How to Test
* use rx-operators snippet

## What to Check
Verify that the following are valid
* the cursor comes on map, which can be changed to something else, or other things can be added easily

@johnpapa 