### PR TITLE
Add NgRx Snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added NgRx snippets for the creator functions: `createAction`, `createEffect`, `createReducer`, and `createSelector`.
 - Updated `ngrx-data` snippets for `NgRx` v8.
+- Fixed display and description names for version 8
 
 <a name="8.0.0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Angular Snippets Changelog
 
+<a name="8.0.1"></a>
+
+# 8.0.1 (2019-06-07)
+
+- Added NgRx snippets for the creator functions: `createAction`, `createEffect`, `createReducer`, and `createSelector`.
+- Updated `ngrx-data` snippets for `NgRx` v8.
+
 <a name="8.0.0"></a>
 
 # 8.0.0 (2019-06-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## Angular Snippets Changelog
 
-<a name="8.0.1"></a>
+<a name="8.1.0"></a>
 
-# 8.0.1 (2019-06-07)
+# 8.1.0 (2019-06-07)
 
 - Added NgRx snippets for the creator functions: `createAction`, `createEffect`, `createReducer`, and `createSelector`.
 - Updated `ngrx-data` snippets for `NgRx` v8.
 - Fixed display and description names for version 8
+- Removed `a-ngrx-data-store-module`, replaced with new `a-ngrx-store-module` and `a-ngrx-data-module-import`
 
 <a name="8.0.0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 # 8.1.0 (2019-06-07)
 
-- Added NgRx snippets for the creator functions: `createAction`, `createEffect`, `createReducer`, and `createSelector`.
-- Updated `ngrx-data` snippets for `NgRx` v8.
+- Added NgRx snippets for the creator functions: `createAction`, `createEffect`, `createReducer`, and `createSelector`
+- Updated `ngrx-data` snippets for `NgRx` version 8
 - Fixed display and description names for version 8
 - Removed `a-ngrx-data-store-module`, replaced with new `a-ngrx-store-module` and `a-ngrx-data-entity-data-module-import`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added NgRx snippets for the creator functions: `createAction`, `createEffect`, `createReducer`, and `createSelector`.
 - Updated `ngrx-data` snippets for `NgRx` v8.
 - Fixed display and description names for version 8
-- Removed `a-ngrx-data-store-module`, replaced with new `a-ngrx-store-module` and `a-ngrx-data-module-import`
+- Removed `a-ngrx-data-store-module`, replaced with new `a-ngrx-store-module` and `a-ngrx-data-entity-data-module-import`
 
 <a name="8.0.0"></a>
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 | `a-ngrx-data-store-module`                   | create an NgRx Data store module                             |
 | `a-ngrx-data-entity-metadata`                | create the entity metadata for NgRx                          |
 | `a-ngrx-data-entity-collection-data-service` | create a data service using NgRx                             |
+| `a-ngrx-create-action`                       | create an action                                             |
+| `a-ngrx-create-action-props`                 | create an action with props                                  |
+| `a-ngrx-create-reducer`                      | create a reducer                                             |
+| `a-ngrx-create-effect`                       | create an effect                                             |
+| `a-ngrx-create-effect-api`                   | create an effect with api call scaffolding                   |
+| `a-ngrx-create-selector`                     | create a selector                                            |
+| `a-ngrx-create-selector-props`               | create a selector with props                                 |
 | `a-output-event`                             | `@Output` event and emitter                                  |
 | `a-pipe`                                     | pipe                                                         |
 | `a-resolver`                                 | resolver                                                     |
@@ -116,3 +123,10 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 1. Select `Install Extension`
 1. Choose the extension
 1. Reload Visual Studio Code
+
+## Credits
+
+Thanks to the following contributors:
+
+- [Wes Grimes](https://twitter.com/wesgrimes)
+- [Tim Deschryver](https://twitter.com/tim_deschryver)

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 | `a-module`                                   | module                                                       |
 | `a-module-root`                              | root app module                                              |
 | `a-module-routing`                           | routing module file (forChild)                               |
-| `a-ngrx-data-store-module`                   | create an NgRx Data store module                             |
-| `a-ngrx-data-entity-metadata`                | create the entity metadata for NgRx                          |
-| `a-ngrx-data-entity-collection-data-service` | create a data service using NgRx                             |
+| `a-ngrx-store-module`                        | create an NgRx store module                                  |
 | `a-ngrx-create-action`                       | create an NgRx action with `createAction`                    |
 | `a-ngrx-create-action-props`                 | create an NgRx action with `createAction` with props         |
 | `a-ngrx-create-reducer`                      | create an NgRx reducer with `createReducer`                  |
@@ -53,6 +51,9 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 | `a-ngrx-create-effect-api`                   | create an NgRx effect with `createEffect` for an API call    |
 | `a-ngrx-create-selector`                     | create an NgRx selector with `createSelector`                |
 | `a-ngrx-create-selector-props`               | create an NgRx selector with `createSelector` with props     |
+| `a-ngrx-data-entity-data-module-import`      | add `EntityDataModule`                                       |
+| `a-ngrx-data-entity-metadata`                | create the entity metadata for NgRx                          |
+| `a-ngrx-data-entity-collection-data-service` | create a data service using NgRx                             |
 | `a-output-event`                             | `@Output` event and emitter                                  |
 | `a-pipe`                                     | pipe                                                         |
 | `a-resolver`                                 | resolver                                                     |

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 | `a-ngrx-data-store-module`                   | create an NgRx Data store module                             |
 | `a-ngrx-data-entity-metadata`                | create the entity metadata for NgRx                          |
 | `a-ngrx-data-entity-collection-data-service` | create a data service using NgRx                             |
-| `a-ngrx-create-action`                       | create an action                                             |
-| `a-ngrx-create-action-props`                 | create an action with props                                  |
-| `a-ngrx-create-reducer`                      | create a reducer                                             |
-| `a-ngrx-create-effect`                       | create an effect                                             |
-| `a-ngrx-create-effect-api`                   | create an effect with api call scaffolding                   |
-| `a-ngrx-create-selector`                     | create a selector                                            |
-| `a-ngrx-create-selector-props`               | create a selector with props                                 |
+| `a-ngrx-create-action`                       | create an NgRx action with `createAction`                    |
+| `a-ngrx-create-action-props`                 | create an NgRx action with `createAction` with props         |
+| `a-ngrx-create-reducer`                      | create an NgRx reducer with `createReducer`                  |
+| `a-ngrx-create-effect`                       | create an NgRx effect with `createEffect`                    |
+| `a-ngrx-create-effect-api`                   | create an NgRx effect with `createEffect` for an API call    |
+| `a-ngrx-create-selector`                     | create an NgRx selector with `createSelector`                |
+| `a-ngrx-create-selector-props`               | create an NgRx selector with `createSelector` with props     |
 | `a-output-event`                             | `@Output` event and emitter                                  |
 | `a-pipe`                                     | pipe                                                         |
 | `a-resolver`                                 | resolver                                                     |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 
 ## Credits
 
-Thanks to the following contributors:
+Thanks to the following contributors for the NgRx snippets:
 
 - [Wes Grimes](https://twitter.com/wesgrimes)
 - [Tim Deschryver](https://twitter.com/tim_deschryver)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "TypeScript",
     "HTML"
   ],
-  "version": "8.0.1",
+  "version": "8.1.0",
   "engines": {
     "vscode": "^1.20.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "TypeScript",
     "HTML"
   ],
-  "version": "8.0.0",
+  "version": "8.0.1",
   "engines": {
     "vscode": "^1.20.0"
   },

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -436,63 +436,6 @@
     "description": "RxJs import",
     "body": ["import { ${1:map} } from 'rxjs/operators';", "$0"]
   },
-  "NgRx Data Module": {
-    "prefix": "a-ngrx-data-store-module",
-    "description": "NgRx Data Store Module",
-    "body": [
-      "import { NgModule } from '@angular/core';",
-      "import { EffectsModule } from '@ngrx/effects';",
-      "import { StoreModule } from '@ngrx/store';",
-      "import { StoreDevtoolsModule } from '@ngrx/store-devtools';",
-      "import { EntityDataModule } from '@ngrx/data';",
-      "import { environment } from '../../environments/environment';",
-      "import { entityConfig } from './entity-metadata';",
-      "",
-      "@NgModule({",
-      "  imports: [",
-      "    StoreModule.forRoot({}),",
-      "    EffectsModule.forRoot([]),",
-      "    environment.production ? [] : StoreDevtoolsModule.instrument(),",
-      "    EntityDataModule.forRoot(entityConfig)",
-      "  ]",
-      "})",
-      "export class AppStoreModule {}"
-    ]
-  },
-  "NgRx Data Entity Metadata": {
-    "prefix": "a-ngrx-data-entity-metadata",
-    "description": "NgRx Data Entity Metadata",
-    "body": [
-      "import { EntityMetadataMap } from '@ngrx/data';",
-      "",
-      "const entityMetadata: EntityMetadataMap = {",
-      "  ${1:Model1}: {},${0}",
-      "};",
-      "",
-      "export const entityConfig = {",
-      "  entityMetadata",
-      "};"
-    ]
-  },
-  "NgRx Data Entity Collection Data Service": {
-    "prefix": "a-ngrx-data-entity-collection-data-service",
-    "description": "NgRx Data Entity Collection Data Service",
-    "body": [
-      "import { Injectable } from '@angular/core';",
-      "import {",
-      "  EntityCollectionServiceBase,",
-      "  EntityCollectionServiceElementsFactory",
-      "} from '@ngrx/data';",
-      "import { ${1:Model} } from '${2:../core}';",
-      "",
-      "@Injectable({ providedIn: 'root' })",
-      "export class ${1:Model}Service extends EntityCollectionServiceBase<${1:Model}> {",
-      "  constructor(serviceElementsFactory: EntityCollectionServiceElementsFactory) {",
-      "    super('${1:Model}', serviceElementsFactory);",
-      "  }",
-      "}"
-    ]
-  },
   "Angular Resolver": {
     "prefix": "a-resolver",
     "description": "Angular Resolver",
@@ -507,6 +450,26 @@
       "\t\treturn ${0};",
       "\t}",
       "}"
+    ]
+  },
+  "NgRx Store Module": {
+    "prefix": "a-ngrx-store-module",
+    "description": "NgRx Store Module",
+    "body": [
+      "import { NgModule } from '@angular/core';",
+      "import { EffectsModule } from '@ngrx/effects';",
+      "import { StoreModule } from '@ngrx/store';",
+      "import { StoreDevtoolsModule } from '@ngrx/store-devtools';",
+      "import { environment } from '../../environments/environment';",
+      "",
+      "@NgModule({",
+      "  imports: [",
+      "    StoreModule.forRoot({}),",
+      "    EffectsModule.forRoot([]),",
+      "    environment.production ? [] : StoreDevtoolsModule.instrument()",
+      "  ]",
+      "})",
+      "export class $1StoreModule {}"
     ]
   },
   "NgRx Create Action": {
@@ -582,6 +545,45 @@
       "\tselect$1,",
       "\t(state: $1State, props) => ${3:selectLogic}",
       ");"
+    ]
+  },
+  "NgRx Data Import Entity Data Module": {
+    "prefix": "a-ngrx-data-entity-data-module-import",
+    "description": "Import NgRx Entity Data Module",
+    "body": ["EntityDataModule.forRoot(${1:entityConfig})"]
+  },
+  "NgRx Data Entity Metadata": {
+    "prefix": "a-ngrx-data-entity-metadata",
+    "description": "NgRx Data Entity Metadata",
+    "body": [
+      "import { EntityMetadataMap } from '@ngrx/data';",
+      "",
+      "const entityMetadata: EntityMetadataMap = {",
+      "  ${1:Model1}: {},${0}",
+      "};",
+      "",
+      "export const entityConfig = {",
+      "  entityMetadata",
+      "};"
+    ]
+  },
+  "NgRx Data Entity Collection Data Service": {
+    "prefix": "a-ngrx-data-entity-collection-data-service",
+    "description": "NgRx Data Entity Collection Data Service",
+    "body": [
+      "import { Injectable } from '@angular/core';",
+      "import {",
+      "  EntityCollectionServiceBase,",
+      "  EntityCollectionServiceElementsFactory",
+      "} from '@ngrx/data';",
+      "import { ${1:Model} } from '${2:../core}';",
+      "",
+      "@Injectable({ providedIn: 'root' })",
+      "export class ${1:Model}Service extends EntityCollectionServiceBase<${1:Model}> {",
+      "  constructor(serviceElementsFactory: EntityCollectionServiceElementsFactory) {",
+      "    super('${1:Model}', serviceElementsFactory);",
+      "  }",
+      "}"
     ]
   }
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -508,5 +508,87 @@
       "\t}",
       "}"
     ]
+  },
+  "NgRx Create Action": {
+    "scope": "typescript",
+    "prefix": "a-ngrx-create-action",
+    "description": "Creates an NgRx Action",
+    "body": [
+      "export const ${1:action} = createAction('[${2:Source}] ${3:Event}');"
+    ]
+  },
+  "NgRx Create Action w/ Props": {
+    "scope": "typescript",
+    "prefix": "ngrx-create-action-props",
+    "description": "Creates an NgRx Action with Props",
+    "body": [
+      "export const ${1:action} = createAction('[${2:Source}] ${3:Event}', props<{${4:key}: ${5:type}}>());"
+    ]
+  },
+  "NgRx Create Reducer": {
+    "scope": "typescript",
+    "prefix": "a-ngrx-create-reducer",
+    "description": "Creates an NgRx Reducer",
+    "body": [
+      "const ${1:feature}Reducer = createReducer(",
+      "\tintialState,",
+      "\ton($1Actions.action, state => ({ ...state, ${2:prop}: ${3:updatedValue} })),",
+      ");",
+      "",
+      "export function reducer(state: State | undefined: action: Action) {",
+      "\treturn $1Reducer(state, action);",
+      "}"
+    ]
+  },
+  "NgRx Create Effect": {
+    "scope": "typescript",
+    "prefix": "a-ngrx-create-effect",
+    "description": "Creates an NgRx Effect",
+    "body": [
+      "${1:effectName}$ = createEffect(() => this.actions$.pipe(",
+      "\tofType(${2:action}.type),",
+      "\t/** An EMPTY observable only emits completion. Replace with your own observable stream */",
+      "\t${3:operator}(() => ${4:EMPTY})",
+      "\t)",
+      ");"
+    ]
+  },
+  "NgRx Create Effect for API Call": {
+    "scope": "typescript",
+    "prefix": "a-ngrx-create-effect-api",
+    "description": "Creates an NgRx Effect Scaffolded for API Call",
+    "body": [
+      "${1:effectName}$ = createEffect(() => this.actions$.pipe(",
+      "\tofType(${2:Feature}Actions.${3:action}.type),",
+      "\t${4:operator}(() =>",
+      "\t\t${5:apiSource}.pipe(",
+      "\t\t\tmap(data => $2Actions.$3Success({ data })),",
+      "\t\t\tcatchError(error => of($2Actions.$3Failure({ error }))))",
+      "\t\t)",
+      "\t)",
+      ");"
+    ]
+  },
+  "NgRx Create Selector": {
+    "scope": "typescript",
+    "prefix": "a-ngrx-create-selector",
+    "description": "Creates an NgRx Selector",
+    "body": [
+      "export const select${1:Feature}${2:Property} = createSelector(",
+      "\tselect$1,",
+      "\t(state: $1State) => state.${3:property}",
+      ");"
+    ]
+  },
+  "NgRx Create Selector w/ Props": {
+    "scope": "typescript",
+    "prefix": "a-ngrx-create-selector-props",
+    "description": "Creates an NgRx Selector using props",
+    "body": [
+      "export const select${1:Feature}${2:Property} = createSelector(",
+      "\tselect$1,",
+      "\t(state: $1State, props) => ${3:selectLogic}",
+      ");"
+    ]
   }
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -444,7 +444,7 @@
       "import { EffectsModule } from '@ngrx/effects';",
       "import { StoreModule } from '@ngrx/store';",
       "import { StoreDevtoolsModule } from '@ngrx/store-devtools';",
-      "import { NgrxDataModule } from 'ngrx-data';",
+      "import { EntityDataModule } from '@ngrx/data';",
       "import { environment } from '../../environments/environment';",
       "import { entityConfig } from './entity-metadata';",
       "",
@@ -453,7 +453,7 @@
       "    StoreModule.forRoot({}),",
       "    EffectsModule.forRoot([]),",
       "    environment.production ? [] : StoreDevtoolsModule.instrument(),",
-      "    NgrxDataModule.forRoot(entityConfig)",
+      "    EntityDataModule.forRoot(entityConfig)",
       "  ]",
       "})",
       "export class AppStoreModule {}"
@@ -463,7 +463,7 @@
     "prefix": "a-ngrx-data-entity-metadata",
     "description": "NgRx Data Entity Metadata",
     "body": [
-      "import { EntityMetadataMap } from 'ngrx-data';",
+      "import { EntityMetadataMap } from '@ngrx/data';",
       "",
       "const entityMetadata: EntityMetadataMap = {",
       "  ${1:Model1}: {},${0}",
@@ -482,7 +482,7 @@
       "import {",
       "  EntityCollectionServiceBase,",
       "  EntityCollectionServiceElementsFactory",
-      "} from 'ngrx-data';",
+      "} from '@ngrx/data';",
       "import { ${1:Model} } from '${2:../core}';",
       "",
       "@Injectable({ providedIn: 'root' })",
@@ -519,7 +519,7 @@
   },
   "NgRx Create Action w/ Props": {
     "scope": "typescript",
-    "prefix": "ngrx-create-action-props",
+    "prefix": "a-ngrx-create-action-props",
     "description": "Creates an NgRx Action with Props",
     "body": [
       "export const ${1:action} = createAction('[${2:Source}] ${3:Event}', props<{${4:key}: ${5:type}}>());"

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -510,7 +510,6 @@
     ]
   },
   "NgRx Create Action": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-action",
     "description": "Creates an NgRx Action",
     "body": [
@@ -518,7 +517,6 @@
     ]
   },
   "NgRx Create Action w/ Props": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-action-props",
     "description": "Creates an NgRx Action with Props",
     "body": [
@@ -526,7 +524,6 @@
     ]
   },
   "NgRx Create Reducer": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-reducer",
     "description": "Creates an NgRx Reducer",
     "body": [
@@ -541,7 +538,6 @@
     ]
   },
   "NgRx Create Effect": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-effect",
     "description": "Creates an NgRx Effect",
     "body": [
@@ -554,7 +550,6 @@
     ]
   },
   "NgRx Create Effect for API Call": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-effect-api",
     "description": "Creates an NgRx Effect Scaffolded for API Call",
     "body": [
@@ -570,7 +565,6 @@
     ]
   },
   "NgRx Create Selector": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-selector",
     "description": "Creates an NgRx Selector",
     "body": [
@@ -581,7 +575,6 @@
     ]
   },
   "NgRx Create Selector w/ Props": {
-    "scope": "typescript",
     "prefix": "a-ngrx-create-selector-props",
     "description": "Creates an NgRx Selector using props",
     "body": [


### PR DESCRIPTION
## Purpose
* Resolves issue #93 

## What
* Added snippets for common NgRx commands including:
  - `createAction`
  - `createEffect`
  - `createReducer`
  - `createSelector`

## How to Test
* Open new `*.ts` file and type `a-ngrx-` and tab complete through the various newly added snippets.

## What to Check
Verify that the following are valid
* Confirm that the createEffect w/ API and createSelector w/ Props are outputting as desired. This is where we can get a little more opinionated, so I tried to stay agnostic.

## Other Notes
Thanks to @timdeschryver and his inspiration with the following gist: https://gist.github.com/timdeschryver/bad232582c01edd4aaffaee1ac9ccfc3