### PR TITLE
Fix typo in NgRx createReducer snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <a name="8.1.1"></a>
 
-# 8.1.1 (2019-06-10)
+# 8.1.1 (2019-06-11)
 
 - Fixed typos in NgRx snippets for `createReducer` and `createEffect`
 - Moved NgRx snippets into separate section of README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Angular Snippets Changelog
 
+<a name="8.1.1"></a>
+
+# 8.1.1 (2019-06-10)
+
+- Fixed typo in NgRx snippet for `createReducer`
+- Moved NgRx snippets into separate section of README
+
 <a name="8.1.0"></a>
 
 # 8.1.0 (2019-06-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # 8.1.1 (2019-06-10)
 
-- Fixed typo in NgRx snippet for `createReducer`
+- Fixed typos in NgRx snippets for `createReducer` and `createEffect`
 - Moved NgRx snippets into separate section of README
 
 <a name="8.1.0"></a>

--- a/README.md
+++ b/README.md
@@ -26,50 +26,55 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 
 ### TypeScript Angular Snippets
 
-| Snippet                                      | Purpose                                                      |
-| -------------------------------------------- | ------------------------------------------------------------ |
-| `a-component`                                | component                                                    |
-| `a-component-inline`                         | component with inline template                               |
-| `a-component-root`                           | root app component                                           |
-| `a-directive`                                | directive                                                    |
-| `a-guard-can-activate`                       | `CanActivate` guard                                          |
-| `a-guard-can-activate-child`                 | `CanActivateChild` guard                                     |
-| `a-guard-can-deactivate`                     | `CanDeactivate` guard                                        |
-| `a-guard-can-load`                           | `CanLoad` guard                                              |
-| `a-httpclient-get`                           | `httpClient.get` with Rx Observable                          |
-| `a-http-interceptor`                         | Empty Angular `HttpInterceptor` for `HttpClient`             |
-| `a-http-interceptor-headers`                 | Angular `HttpInterceptor` that sets headers for `HttpClient` |
-| `a-http-interceptor-logging`                 | Angular `HttpInterceptor` that logs traffic for `HttpClient` |
-| `a-module`                                   | module                                                       |
-| `a-module-root`                              | root app module                                              |
-| `a-module-routing`                           | routing module file (forChild)                               |
-| `a-ngrx-store-module`                        | create an NgRx store module                                  |
-| `a-ngrx-create-action`                       | create an NgRx action with `createAction`                    |
-| `a-ngrx-create-action-props`                 | create an NgRx action with `createAction` with props         |
-| `a-ngrx-create-reducer`                      | create an NgRx reducer with `createReducer`                  |
-| `a-ngrx-create-effect`                       | create an NgRx effect with `createEffect`                    |
-| `a-ngrx-create-effect-api`                   | create an NgRx effect with `createEffect` for an API call    |
-| `a-ngrx-create-selector`                     | create an NgRx selector with `createSelector`                |
-| `a-ngrx-create-selector-props`               | create an NgRx selector with `createSelector` with props     |
-| `a-ngrx-data-entity-data-module-import`      | add `EntityDataModule`                                       |
-| `a-ngrx-data-entity-metadata`                | create the entity metadata for NgRx                          |
-| `a-ngrx-data-entity-collection-data-service` | create a data service using NgRx                             |
-| `a-output-event`                             | `@Output` event and emitter                                  |
-| `a-pipe`                                     | pipe                                                         |
-| `a-resolver`                                 | resolver                                                     |
-| `a-rxjs-import`                              | import RxJs features                                         |
-| `a-rxjs-operators`                           | import RxJs operators                                        |
-| `a-route-path-404`                           | 404 route path                                               |
-| `a-route-path-default`                       | default route path                                           |
-| `a-route-path-with-children`                 | route path with children                                     |
-| `a-route-path-eager`                         | eager route path                                             |
-| `a-route-path-lazy`                          | lazy route path                                              |
-| `a-router-events`                            | listen to one or more router events                          |
-| `a-route-params-subscribe`                   | subscribe to route parameters                                |
-| `a-service`                                  | service                                                      |
-| `a-service-httpclient`                       | service with `HttpClient`                                    |
-| `a-ctor-skip-self`                           | angular `NgModule`'s `skipself` constructor                  |
-| `a-subscribe`                                | Rx Observable subscription                                   |
+| Snippet                      | Purpose                                                      |
+| ---------------------------- | ------------------------------------------------------------ |
+| `a-component`                | component                                                    |
+| `a-component-inline`         | component with inline template                               |
+| `a-component-root`           | root app component                                           |
+| `a-directive`                | directive                                                    |
+| `a-guard-can-activate`       | `CanActivate` guard                                          |
+| `a-guard-can-activate-child` | `CanActivateChild` guard                                     |
+| `a-guard-can-deactivate`     | `CanDeactivate` guard                                        |
+| `a-guard-can-load`           | `CanLoad` guard                                              |
+| `a-httpclient-get`           | `httpClient.get` with Rx Observable                          |
+| `a-http-interceptor`         | Empty Angular `HttpInterceptor` for `HttpClient`             |
+| `a-http-interceptor-headers` | Angular `HttpInterceptor` that sets headers for `HttpClient` |
+| `a-http-interceptor-logging` | Angular `HttpInterceptor` that logs traffic for `HttpClient` |
+| `a-module`                   | module                                                       |
+| `a-module-root`              | root app module                                              |
+| `a-module-routing`           | routing module file (forChild)                               |
+| `a-output-event`             | `@Output` event and emitter                                  |
+| `a-pipe`                     | pipe                                                         |
+| `a-resolver`                 | resolver                                                     |
+| `a-rxjs-import`              | import RxJs features                                         |
+| `a-rxjs-operators`           | import RxJs operators                                        |
+| `a-route-path-404`           | 404 route path                                               |
+| `a-route-path-default`       | default route path                                           |
+| `a-route-path-with-children` | route path with children                                     |
+| `a-route-path-eager`         | eager route path                                             |
+| `a-route-path-lazy`          | lazy route path                                              |
+| `a-router-events`            | listen to one or more router events                          |
+| `a-route-params-subscribe`   | subscribe to route parameters                                |
+| `a-service`                  | service                                                      |
+| `a-service-httpclient`       | service with `HttpClient`                                    |
+| `a-ctor-skip-self`           | angular `NgModule`'s `skipself` constructor                  |
+| `a-subscribe`                | Rx Observable subscription                                   |
+
+### NgRx Snippets
+
+| Snippet                                      | Purpose                                                   |
+| -------------------------------------------- | --------------------------------------------------------- |
+| `a-ngrx-store-module`                        | create an NgRx store module                               |
+| `a-ngrx-create-action`                       | create an NgRx action with `createAction`                 |
+| `a-ngrx-create-action-props`                 | create an NgRx action with `createAction` with props      |
+| `a-ngrx-create-reducer`                      | create an NgRx reducer with `createReducer`               |
+| `a-ngrx-create-effect`                       | create an NgRx effect with `createEffect`                 |
+| `a-ngrx-create-effect-api`                   | create an NgRx effect with `createEffect` for an API call |
+| `a-ngrx-create-selector`                     | create an NgRx selector with `createSelector`             |
+| `a-ngrx-create-selector-props`               | create an NgRx selector with `createSelector` with props  |
+| `a-ngrx-data-entity-data-module-import`      | add `EntityDataModule`                                    |
+| `a-ngrx-data-entity-metadata`                | create the entity metadata for NgRx                       |
+| `a-ngrx-data-entity-collection-data-service` | create a data service using NgRx                          |
 
 ### Dockerfile Snippets
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "TypeScript",
     "HTML"
   ],
-  "version": "8.1.0",
+  "version": "8.1.1",
   "engines": {
     "vscode": "^1.20.0"
   },

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -491,7 +491,7 @@
     "description": "Creates an NgRx Reducer",
     "body": [
       "const ${1:feature}Reducer = createReducer(",
-      "\tintialState,",
+      "\tinitialState,",
       "\ton($1Actions.action, state => ({ ...state, ${2:prop}: ${3:updatedValue} })),",
       ");",
       "",

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -495,7 +495,7 @@
       "\ton($1Actions.action, state => ({ ...state, ${2:prop}: ${3:updatedValue} })),",
       ");",
       "",
-      "export function reducer(state: State | undefined: action: Action) {",
+      "export function reducer(state: State | undefined, action: Action) {",
       "\treturn $1Reducer(state, action);",
       "}"
     ]

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -505,7 +505,7 @@
     "description": "Creates an NgRx Effect",
     "body": [
       "${1:effectName}$ = createEffect(() => this.actions$.pipe(",
-      "\tofType(${2:action}.type),",
+      "\tofType(${2:action}),",
       "\t/** An EMPTY observable only emits completion. Replace with your own observable stream */",
       "\t${3:operator}(() => ${4:EMPTY})",
       "\t)",
@@ -517,7 +517,7 @@
     "description": "Creates an NgRx Effect Scaffolded for API Call",
     "body": [
       "${1:effectName}$ = createEffect(() => this.actions$.pipe(",
-      "\tofType(${2:Feature}Actions.${3:action}.type),",
+      "\tofType(${2:Feature}Actions.${3:action}),",
       "\t${4:operator}(() =>",
       "\t\t${5:apiSource}.pipe(",
       "\t\t\tmap(data => $2Actions.$3Success({ data })),",


### PR DESCRIPTION
## Purpose
* Fixes typo in `createReducer` snippet

## What
* Fixes typo in `createReducer` snippet
* Reorganize NgRx snippets into a separate section of the README

## How to Test
* ...

## What to Check
Verify that the following are valid
* ...