### PR TITLE
Add a-spec-with-before-each and a-spec snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Angular2",
-  "version": "7.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -586,4 +586,37 @@
       "}"
     ]
   }
+},
+"Spec with beforeEach": {
+  "prefix": "a-spec-with-before-each",
+  "description": "Component Spec with beforeEach",
+  "body": [      
+    "import { TestBed, async } from '@angular/core/testing';",
+    "import { RouterTestingModule } from '@angular/router/testing';",
+    "import { ${1:Name}Component } from './${2:name}.component';",
+    "",
+    "describe('${3:description}', () => {",
+    "\tbeforeEach(async(() => {",
+    "\t\tTestBed.configureTestingModule({",
+    "\t\t\timports: [],",
+    "\t\t\tdeclarations: [${1:Name}Component]",
+    "\t\t}).compileComponents();",
+    "\t}));",
+    "",
+    "\tit('should ${4:assert-description}', () => {",
+    "\t\texpect(fail());",
+    "\t});",
+    "});",
+    ""
+  ]
+},
+"Simple spec": {
+  "prefix": "a-spec",
+  "description": "Simple spec",
+  "body": [
+    "it('should ${1:should-description}', () => {",
+    "\texpect(fail());",
+    "});",
+    ""
+  ]
 }


### PR DESCRIPTION
## Purpose
* Add snippets for specs

## What
* Add snippets to typescript.json

## How to Test
* type `a-spec-with-before-each` and press tab
* type `a-spec` and press tab

## What to Check
Verify that the following are valid
* `a-spec-with-before-each` should stub out a describe block with corresponding import statements and placeholders for the component name
* `a-spec` should stub out an `it()` block with the expectation initially marked to fail