### PR TITLE
Fix #95

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -107,9 +107,9 @@
     "prefix": "a-route-params-subscribe",
     "description": "Angular - subscribe to routing parameters",
     "body": [
-      "this.route.params",
-      "\t.pipe(map(params => params['id']), tap(id => (this.id = +id)))",
-      "\t.subscribe(id => ${1:function()}());",
+      "this.route.paramMap",
+      "\t.pipe(switchMap(params => params.get('id')), tap(id => (this.id = +id)))",
+      "\t.subscribe(id => {$1});",
       "$0"
     ]
   },


### PR DESCRIPTION
## Purpose
* Fix #95 

## What
* Fixes it by replacing `params` with `paramMap` and removing the function part
