### PR TITLE
Update a-http-interceptor-logging for RxJS move

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -137,7 +137,8 @@
     "description": "Angular HttpInterceptor for Logging HttpClient",
     "body": [
       "import { HttpInterceptor, HttpHandler, HttpRequest, HttpEvent, HttpResponse } from '@angular/common/http';",
-      "import { Observable, tap } from 'rxjs';",
+      "import { Observable } from 'rxjs';",
+      "import { tap } from 'rxjs/operators';",
       "",
       "@Injectable({providedIn: ${1:'root'}})",
       "export class LogInterceptor implements HttpInterceptor {",


### PR DESCRIPTION
'tap' operator was moved to /operators sub folder in  #RxJS.
This fixes the imports when using the logging interceptor snippet

## Purpose
* Fixes issue #106, RxJS tap operator moved to /operators folder

## What
* a-http-interceptor-logging snippet has bad import of tap operator

## How to Test
* use the a-http-interceptor snippet on a project with RxJS 6.0.0 or higher

## What to Check
Verify that the following are valid
* Three imports should be added to the top of the snippet instead of just two
 -- Various HTTP classes from '@angular/common/http'
 -- Observable from `rxjs`
 -- tap from 'rxjs/operators'