### PR TITLE
Fixing implementation of "a-route-params-subscribe" snippet

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -108,7 +108,7 @@
     "description": "Angular - subscribe to routing parameters",
     "body": [
       "this.route.paramMap",
-      "\t.pipe(switchMap(params => params.get('id')), tap(id => (this.id = +id)))",
+      "\t.pipe(map(params => params.get('id')), tap(id => (this.id = +id)))",
       "\t.subscribe(id => {$1});",
       "$0"
     ]


### PR DESCRIPTION
## Purpose
The old faulty implementation in the typescript.json did use a switchMap which would lead to problematic behavior. Replaced it with the map operator. This should fix #113 

## What
typescript.json