### PR TITLE
Improved the switch snippet

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -104,10 +104,10 @@
   "ngSwitch": {
     "prefix": "a-ngSwitch",
     "body": [
-      "<div [ngSwitch]=\"${1:conditionExpression}\">",
-      "\t<div *ngSwitchCase=\"${2:expression}\">${3:output}</div>",
-      "\t<div *ngSwitchDefault>${4:output2}</div>",
-      "</div>"
+      "<ng-container [ngSwitch]=\"${1:conditionExpression}\">",
+      "\t<ng-container *ngSwitchCase=\"${2:expression}\">${3:output}</ng-container>",
+      "\t<ng-container *ngSwitchDefault>${4:output2}</ng-container>",
+      "</ng-container>"
     ],
     "description": "Angular ngSwitch"
   },


### PR DESCRIPTION
Improved the switch snippet so it uses ng-container elements instead of div elements

## Purpose
When adding an ngSwitch using the snippet it's useful to use the ng-container elements instead of the div elements so there are less DOM elements in the outputted code.

I found myself changing the default all the time so therefor this PR.

Thank you for this nice extension!