### PR TITLE
ngcontent selector  should be wrapped in square brackets

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -133,7 +133,7 @@
   },
   "ng-content": {
     "prefix": "a-ng-content",
-    "body": ["<ng-content select=\"${0:selector}\"></ng-content>"],
+    "body": ["<ng-content select=\"[${0:selector}]\"></ng-content>"],
     "description": "Angular ng-content"
   }
 }


### PR DESCRIPTION
According the angular docs the `ng-content` selector should be wrapped in brackets which is not done properly currently by the snippet.

Before
```<ng-content select="select"></ng-content>```

After
```<ng-content select="[select]"></ng-content>```
