### PR TITLE
Fix snippet a-ng-template uses deprecated API

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -128,7 +128,7 @@
   },
   "ng-template": {
     "prefix": "a-ng-template",
-    "body": ["<ng-template [ngTemplateOutlet]=\"${1:outlet}\" [ngOutletContext]=\"${2:context}\"></ng-template>"],
+    "body": ["<ng-template [ngTemplateOutlet]=\"${1:outlet}\" [ngTemplateOutletContext]=\"${2:context}\"></ng-template>"],
     "description": "Angular ng-template"
   },
   "ng-content": {


### PR DESCRIPTION
Per [documentation](https://angular.io/api/common/NgTemplateOutlet#properties) there is no `ngOutletContext` input - it was renamed to `ngTemplateOutletContext` back in v5.

## Purpose
* make `a-ng-template` snippet compatible with latest versions of Angular

## What
* `ngOutletContext` input renamed to `ngTemplateOutletContext`

## How to Test
* a-ng-template

## What to Check
Verify that the following are valid
* a-ng-template