### PR TITLE
Angular 22 refresh + issue triage updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -59,7 +59,7 @@ body:
     id: extension-version
     attributes:
       label: Extension version
-      placeholder: "18.0.2"
+      placeholder: "22.0.0"
     validations:
       required: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Each snippet file is scoped to a specific VS Code language ID via `package.json`
 
 ### Version tracking
 
-The extension version tracks Angular major versions (e.g., `18.x.x` for Angular 18). The `displayName` in `package.json` also reflects the current Angular version.
+The extension version tracks Angular major versions (e.g., `22.x.x` for Angular 22). The `displayName` in `package.json` also reflects the current Angular version.
 
 ## Adding a New Snippet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Angular Snippets Changelog
 
+<a name="22.0.0"></a>
+
+# 22.0.0 (2026-07-19)
+
+- updated extension metadata and docs for Angular 22
+- modernized key snippets:
+  - added `a-route-path-lazy-component` for standalone lazy loading with `loadComponent`
+  - updated `a-component-root` to standalone style with `RouterOutlet` imports
+  - replaced deprecated `HttpModule` usage in `a-module-root` with `HttpClientModule`
+  - updated `a-resolver` to functional `ResolveFn`
+  - updated `a-rxjs-operator-import` to import operators from `rxjs`
+- improved control-flow coverage in templates:
+  - added `a-if` (`@if`) and `a-for` (`@for`) HTML snippets
+- fixed snippet issues:
+  - fixed `a-guard-can-activate-child` to export the guard constant
+  - corrected `a-guard-can-match` placeholder numbering and imports
+  - fixed `a-ctor-skip-self` constructor signature
+
 <a name="18.0.0"></a>
 
 # 18.0.0 (2024-07-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - fixed `a-guard-can-activate-child` to export the guard constant
   - corrected `a-guard-can-match` placeholder numbering and imports
   - fixed `a-ctor-skip-self` constructor signature
+  - fixed `a-ngFor-trackBy` to use a trackBy function placeholder
+- added explicit VS Code virtual workspace support via `capabilities.virtualWorkspaces`
 
 <a name="18.0.0"></a>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen?style=flat)](https://github.com/johnpapa/ai-ready)
 
-**Updated for Angular 18 release**
+**Updated for Angular 22 release**
 
 This extension for Visual Studio Code adds snippets for Angular for TypeScript and HTML.
 
@@ -53,12 +53,13 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (macOS) to
 | `a-resolver`                 | resolver                                                             |
 | `a-routes`                   | Route definition file                                                |
 | `a-rxjs-import`              | import RxJs features                                                 |
-| `a-rxjs-operators`           | import RxJs operators                                                |
+| `a-rxjs-operator-import`     | import RxJs operators                                                |
 | `a-route-path-404`           | 404 route path                                                       |
 | `a-route-path-default`       | default route path                                                   |
 | `a-route-path-with-children` | route path with children                                             |
 | `a-route-path-eager`         | eager route path                                                     |
-| `a-route-path-lazy`          | lazy route path                                                      |
+| `a-route-path-lazy`          | lazy route path for module loading                                  |
+| `a-route-path-lazy-component`| lazy route path for standalone component loading                    |
 | `a-router-events`            | listen to one or more router events                                  |
 | `a-route-params-subscribe`   | subscribe to route parameters                                        |
 | `a-service`                  | service with injectable provided in root                             |
@@ -113,6 +114,8 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (macOS) to
 | `a-form-submit`      | create a submit button for a form                   |
 | `a-ngIf`             | `*ngIf`                                             |
 | `a-ngIfElse`         | `*ngIf` with `else`                                 |
+| `a-if`               | `@if` control-flow block                            |
+| `a-for`              | `@for` control-flow block                           |
 | `a-ngModel`          | `ngModel`                                           |
 | `a-routerLink`       | `routerLink`                                        |
 | `a-routerLink-param` | `routerLink` with a route parameter                 |

--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ Type part of a snippet, press `enter`, and the snippet unfolds.
 
 Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (macOS) to activate snippets from within the editor.
 
-### Command Palette Commands
-
-| Command                                              | Purpose                     |
-| ---------------------------------------------------- | --------------------------- |
-| express: Add simple Express server file to workspace | Adds Node.js express server |
-
 ### TypeScript Angular Snippets
 
 | Snippet                      | Purpose                                                              |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Angular TypeScript Snippets for VS Code
 
-[![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen?style=flat)](https://github.com/johnpapa/ai-ready)
+[AI Ready project](https://github.com/johnpapa/ai-ready)
 
 **Updated for Angular 22 release**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Angular2",
-  "version": "18.0.2",
+  "version": "22.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Angular2",
-      "version": "18.0.2",
+      "version": "22.0.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "Angular2",
   "publisher": "johnpapa",
-  "displayName": "Angular Snippets (Version 18)",
-  "description": "Angular version 18 snippets by John Papa",
-  "version": "18.0.2",
+  "displayName": "Angular Snippets (Version 22)",
+  "description": "Angular version 22 snippets by John Papa",
+  "version": "22.0.0",
   "icon": "images/angular-shield.png",
   "galleryBanner": {
     "color": "#0273D4",
@@ -16,7 +16,7 @@
   },
   "keywords": [
     "Angular",
-    "Angular 18",
+    "Angular 22",
     "TypeScript",
     "HTML"
   ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "ui",
     "workspace"
   ],
+  "capabilities": {
+    "virtualWorkspaces": true
+  },
   "categories": [
     "Snippets",
     "Other"

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -21,7 +21,7 @@
   },
   "ngFor with trackBy": {
     "prefix": "a-ngFor-trackBy",
-    "body": ["*ngFor=\"let ${1:item} of ${2:list}; trackBy:${1:trackByFnName}\"${0}"],
+    "body": ["*ngFor=\"let ${1:item} of ${2:list}; trackBy:${3:trackByFnName}\"${0}"],
     "description": "Angular *ngFor with trackBy"
   },
   "ngForAsync": {

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -69,6 +69,16 @@
     "body": ["*ngIf=\"${1:expression};else ${2:templateName}\""],
     "description": "Angular *ngIfElse"
   },
+  "@if block": {
+    "prefix": "a-if",
+    "body": ["@if (${1:expression}) {", "\t${0}", "}"],
+    "description": "Angular @if control-flow block"
+  },
+  "@for block": {
+    "prefix": "a-for",
+    "body": ["@for (${1:item} of ${2:items}; track ${3:item.id}) {", "\t${0}", "}"],
+    "description": "Angular @for control-flow block"
+  },
   "ngModel": {
     "prefix": "a-ngModel",
     "body": ["[(ngModel)]=\"${1:binding}\""],

--- a/snippets/jsonc.json
+++ b/snippets/jsonc.json
@@ -1,6 +1,7 @@
 {
   "Create launch config for Chrome": {
     "prefix": "a-launch-chrome",
+    "description": "Launch/debug configuration for VS Code for Chrome",
     "body": [
       "{",
       "\t\"name\": \"Launch Angular\",",
@@ -14,6 +15,7 @@
   },
   "Create launch config for Edge": {
     "prefix": "a-launch-edge",
+    "description": "Launch/debug configuration for VS Code for Edge",
     "body": [
       "{",
       "\t\"name\": \"Launch Angular\",",
@@ -28,6 +30,7 @@
   },
   "Create task to start Angular": {
     "prefix": "a-task-start",
+    "description": "Create a task to start Angular for VS Code",
     "body": [
       "{",
       "\t\"type\": \"npm\",",

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -123,6 +123,16 @@
       "},$0"
     ]
   },
+  "Angular Lazy Route Path - Standalone Component": {
+    "prefix": "a-route-path-lazy-component",
+    "description": "Angular lazy route path for a standalone component",
+    "body": [
+      "{",
+      "\tpath: '${1:path}',",
+      "\tloadComponent: () => import('${2:lazy-path}').then(c => c.${3:LazyComponent})",
+      "},$0"
+    ]
+  },
   "Routing Params - Subscribe": {
     "prefix": "a-route-params-subscribe",
     "description": "Angular - subscribe to routing parameters",
@@ -158,7 +168,7 @@
     "body": [
       "import { HttpInterceptor, HttpHandler, HttpRequest, HttpEvent, HttpResponse } from '@angular/common/http';",
       "import { Observable } from 'rxjs';",
-      "import { tap } from 'rxjs/operators';",
+      "import { tap } from 'rxjs';",
       "",
       "@Injectable()",
       "export class LogInterceptor implements HttpInterceptor {",
@@ -230,8 +240,11 @@
     "description": "Angular App root component",
     "body": [
       "import { Component } from '@angular/core';",
+      "import { RouterOutlet } from '@angular/router';",
       "",
       "@Component({",
+      "\tstandalone: true,",
+      "\timports: [RouterOutlet],",
       "\tselector: '${1:prefix-app}',",
       "\ttemplate: `",
       "\t\t<router-outlet></router-outlet>",
@@ -247,14 +260,14 @@
     "body": [
       "import { NgModule } from '@angular/core';",
       "import { BrowserModule  } from '@angular/platform-browser';",
-      "import { HttpModule } from '@angular/http';",
+      "import { HttpClientModule } from '@angular/common/http';",
       "",
       "import { ${1:App}Component } from './${1:app}.component';",
       "",
       "@NgModule({",
       "\timports: [",
       "\t\tBrowserModule,",
-      "\t\tHttpModule,",
+      "\t\tHttpClientModule,",
       "\t],",
       "\tdeclarations: [${1:App}Component],",
       "\tbootstrap: [${1:App}Component],",
@@ -324,14 +337,13 @@
     "prefix": "a-guard-can-activate-child",
     "description": "Angular CanActivateChild guard",
     "body": [
-      "import { inject } from '@angular/core';",
       "import {",
       "  ActivatedRouteSnapshot,",
       "  CanActivateChildFn,",
       "  RouterStateSnapshot,",
       "} from '@angular/router';",
       "",
-      "const ${1:Name}Guard: CanActivateChildFn = (",
+      "export const ${1:Name}Guard: CanActivateChildFn = (",
       "  route: ActivatedRouteSnapshot,",
       "  state: RouterStateSnapshot",
       ") => {",
@@ -343,15 +355,14 @@
     "prefix": "a-guard-can-match",
     "description": "Angular Functional CanMatchFn guard",
     "body": [
-      "import { inject } from '@angular/core';",
-      "import { CanMatchFn, Route, Router, UrlSegment } from '@angular/router';",
+      "import { CanMatchFn, Route, UrlSegment } from '@angular/router';",
       "",
-      "export const ${2:Name}Guard: CanMatchFn = (",
+      "export const ${1:Name}Guard: CanMatchFn = (",
       "\troute: Route,",
       "\tsegments: UrlSegment[]",
       ") => {",
       "\treturn true;$0",
-      "}"
+      "};"
     ]
   },
   "Angular CanDeactivate Guard": {
@@ -455,7 +466,7 @@
     "prefix": "a-ctor-skip-self",
     "description": "Angular Module SkipSelf constructor",
     "body": [
-      "constructor( @Optional() @SkipSelf() parentModule: ${1:ModuleName} {",
+      "constructor(@Optional() @SkipSelf() parentModule: ${1:ModuleName}) {",
       "\tif (parentModule) {",
       "\t\tconst msg = `${1:ModuleName} has already been loaded. ",
       "\t\t\tImport ${1:ModuleName} once, only, in the root AppModule.`;",
@@ -471,23 +482,21 @@
   },
   "RxJs Operator Import": {
     "prefix": "a-rxjs-operator-import",
-    "description": "RxJs import",
-    "body": ["import { ${1:map} } from 'rxjs/operators';", "$0"]
+    "description": "RxJs operator import",
+    "body": ["import { ${1:map} } from 'rxjs';", "$0"]
   },
   "Angular Resolver": {
     "prefix": "a-resolver",
     "description": "Angular Resolver",
     "body": [
-      "import { Injectable } from '@angular/core';",
-      "import { Resolve, ActivatedRouteSnapshot } from '@angular/router';",
-      "import { Observable } from 'rxjs';",
+      "import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';",
       "",
-      "@Injectable({ providedIn: ${1:'root'} })",
-      "export class ${2:YourResolver} implements Resolve<${3:ObjectToResolve}> {",
-      "\tresolve(route: ActivatedRouteSnapshot): Observable<${3:ObjectToResolve}> | Promise<${3:ObjectToResolve}> | ${3:ObjectToResolve} {",
-      "\t\treturn ${0};",
-      "\t}",
-      "}"
+      "export const ${1:yourResolver}: ResolveFn<${2:ObjectToResolve}> = (",
+      "\troute: ActivatedRouteSnapshot,",
+      "\tstate: RouterStateSnapshot",
+      ") => {",
+      "\treturn ${0};",
+      "};"
     ]
   },
   "NgRx Store Module": {


### PR DESCRIPTION
## Summary

- Refresh extension metadata and docs for Angular 22
- Modernize key TypeScript and HTML snippets for current Angular patterns
- Add `a-if` / `a-for` snippets and a standalone lazy-route snippet
- Fix `a-ngFor-trackBy` placeholder behavior
- Declare virtual workspace support in `package.json`

## Changes

- Version metadata updated to `22.0.0` across extension files/docs
- Added `a-route-path-lazy-component` using `loadComponent`
- Updated root component snippet to standalone style with `RouterOutlet`
- Replaced deprecated `HttpModule` with `HttpClientModule` in root module snippet
- Updated resolver snippet to functional `ResolveFn`
- Updated RxJS operator import snippets to import from `rxjs`
- Added HTML control-flow snippets: `a-if`, `a-for`
- Fixed `a-guard-can-activate-child`, `a-guard-can-match`, and `a-ctor-skip-self`
- Added `capabilities.virtualWorkspaces: true`

## Closes

- Closes #150
- Closes #132
- Closes #127