### PR TITLE
Remove unnecessary .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    }
-  }
-}


### PR DESCRIPTION
## Summary

- remove root `.mcp.json` added during AI-ready pass

## Why

- this snippets extension does not use project-specific MCP servers
- keeping only repo-required config avoids extra maintenance noise

## Scope

- no snippet/content/version changes
- no workflow changes